### PR TITLE
feat: gtk4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Before you clone the shard and build it, install the GTK libraries.
 git clone git@github.com:grkek/haki.git
 cd haki
 shards install
+./bin/gi-crystal
 ```
 
 # Usage

--- a/shard.yml
+++ b/shard.yml
@@ -8,8 +8,8 @@ dependencies:
   duktape:
     github: jessedoyle/duktape.cr
 
-  gobject:
-    github: jhass/crystal-gobject
+  gtk4:
+    github: hugopl/gtk4.cr
 
 development_dependencies:
   ameba:

--- a/src/haki/builder.cr
+++ b/src/haki/builder.cr
@@ -1,4 +1,4 @@
-require "gobject/gtk"
+require "gtk4"
 require "uuid"
 
 module Haki
@@ -21,7 +21,7 @@ module Haki
             application_id: structure.as(Element).attributes["applicationId"]? || ["com", "haki", UUID.random.hexstring].join(".")
           )
 
-          application.on_activate do
+          application.activate_signal.connect do
             build_components(structure, application)
 
             elements = structure.children.reject! do |child|
@@ -37,7 +37,7 @@ module Haki
               Duktape::Engine.instance.eval! script
             end
 
-            window.try(&.show_all)
+            window.try(&.show)
           end
 
           application.run
@@ -106,8 +106,8 @@ module Haki
       css_provider = Gtk::CssProvider.new
       css_provider.load_from_path(child.attributes["src"])
       display = Gdk::Display.default.not_nil!
-      screen = display.default_screen
-      Gtk::StyleContext.add_provider_for_screen screen, css_provider, Gtk::STYLE_PROVIDER_PRIORITY_APPLICATION
+
+      Gtk::StyleContext.add_provider_for_display(display, css_provider, Gtk::STYLE_PROVIDER_PRIORITY_APPLICATION.to_u32)
     end
 
     # Build components from the main document model, start with either a StyleSheet component or the Window component.

--- a/src/haki/dom/box.cr
+++ b/src/haki/dom/box.cr
@@ -27,11 +27,11 @@ module Haki
 
         case @attributes["orientation"]?
         when "vertical"
-          orientation = Gtk::Orientation::VERTICAL
+          orientation = Gtk::Orientation::Vertical
         when "horizontal"
-          orientation = Gtk::Orientation::HORIZONTAL
+          orientation = Gtk::Orientation::Horizontal
         else
-          orientation = Gtk::Orientation::VERTICAL
+          orientation = Gtk::Orientation::Vertical
         end
 
         spacing = @attributes["spacing"]? || "2"
@@ -40,15 +40,17 @@ module Haki
 
         Duktape::Engine.instance.eval! ["const", id, "=", {type: "Box", className: class_name, availableCallbacks: ["onEvent"]}.to_json].join(" ")
 
-        box.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            Duktape::Engine.instance.eval! [id, ".", "onEvent", "(", "\"", event.event_type.to_s, "\"", ")"].join
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     Duktape::Engine.instance.eval! [id, ".", "onEvent", "(", "\"", event.event_type.to_s, "\"", ")"].join
+        #     true
+        #   end
+        # end
+        # box.add_controller(event_controller)
 
         containerize(widget, box, box_expand, box_fill, box_padding)
         add_class_to_css(box, class_name)

--- a/src/haki/dom/button.cr
+++ b/src/haki/dom/button.cr
@@ -32,28 +32,30 @@ module Haki
 
         case relief
         when "none"
-          relief_style = Gtk::ReliefStyle::NONE
+          relief_style = false
         when "normal"
-          relief_style = Gtk::ReliefStyle::NORMAL
+          relief_style = true
         else
-          relief_style = Gtk::ReliefStyle::NORMAL
+          relief_style = false
         end
 
-        button = Gtk::Button.new(name: id, label: text, relief: relief_style, halign: horizontal_align, valign: vertical_align)
+        button = Gtk::Button.new(name: id, label: text, has_frame: relief_style, halign: horizontal_align, valign: vertical_align)
 
         Duktape::Engine.instance.eval! ["const", id, "=", {type: "Button", className: class_name, availableCallbacks: ["onEvent", "onClick"]}.to_json].join(" ")
 
-        button.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            Duktape::Engine.instance.eval! [id, ".", "onEvent", "(", "\"", event.event_type.to_s, "\"", ")"].join
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     Duktape::Engine.instance.eval! [id, ".", "onEvent", "(", "\"", event.event_type.to_s, "\"", ")"].join
+        #     true
+        #   end
+        # end
+        # button.add_controller(event_controller)
 
-        button.on_clicked do
+        button.clicked_signal.connect do
           Duktape::Engine.instance.eval! [id, ".", "onClick", "()"].join
         end
 

--- a/src/haki/dom/element.cr
+++ b/src/haki/dom/element.cr
@@ -37,17 +37,17 @@ module Haki
       private def to_align(str : String) : Gtk::Align
         case str
         when "fill"
-          Gtk::Align::FILL
+          Gtk::Align::Fill
         when "start"
-          Gtk::Align::START
+          Gtk::Align::Start
         when "end"
-          Gtk::Align::END
+          Gtk::Align::End
         when "center"
-          Gtk::Align::CENTER
+          Gtk::Align::Center
         when "baseline"
-          Gtk::Align::BASELINE
+          Gtk::Align::Baseline
         else
-          Gtk::Align::BASELINE
+          Gtk::Align::Baseline
         end
       end
 
@@ -71,13 +71,23 @@ module Haki
         when Gtk::Notebook
           widget.append_page(component, nil)
         when Gtk::Box
-          widget.pack_start(component, to_bool(box_expand), to_bool(box_fill), box_padding.to_i)
+          expand = to_bool(box_expand)
+          component.hexpand = expand
+          component.vexpand = expand
+
+          margin = box_padding.to_i
+          component.margin_top = margin
+          component.margin_bottom = margin
+          component.margin_start = margin
+          component.margin_end = margin
+
+          widget.append(component)
         when Gtk::ScrolledWindow, Gtk::Frame
-          widget.add(component)
+          widget.child = component
         when Gtk::ListBox
           widget.insert(component, 1_000_000)
         when Gtk::ApplicationWindow
-          widget.add(component)
+          widget.child = component
         end
       end
 

--- a/src/haki/dom/entry.cr
+++ b/src/haki/dom/entry.cr
@@ -31,27 +31,27 @@ module Haki
 
         Duktape::Engine.instance.eval! ["const", id, "=", {type: "Entry", className: class_name, avaliableCallbacks: ["onInsertedText", "onDeletedText", "onCutClipboard", "onCopyClipboard", "onPasteClipboard", "onActivate"]}.to_json].join(" ")
 
-        entry.buffer.on_inserted_text do |buffer|
-          Duktape::Engine.instance.eval! [id, ".", "onInsertedText", "(", "\"", buffer.text, "\"", ")"].join
+        entry.buffer.inserted_text_signal.connect do
+          Duktape::Engine.instance.eval! [id, ".", "onInsertedText", "(", "\"", entry.buffer.text, "\"", ")"].join
         end
 
-        entry.buffer.on_deleted_text do |buffer|
-          Duktape::Engine.instance.eval! [id, ".", "onDeletedText", "(", "\"", buffer.text, "\"", ")"].join
+        entry.buffer.deleted_text_signal.connect do
+          Duktape::Engine.instance.eval! [id, ".", "onDeletedText", "(", "\"", entry.buffer.text, "\"", ")"].join
         end
 
-        entry.on_cut_clipboard do
-          Duktape::Engine.instance.eval! [id, ".", "onCutClipboard", "(", "\"", entry.buffer.text, "\"", ")"].join
-        end
+        # entry.on_cut_clipboard do
+        #   Duktape::Engine.instance.eval! [id, ".", "onCutClipboard", "(", "\"", entry.buffer.text, "\"", ")"].join
+        # end
 
-        entry.on_copy_clipboard do
-          Duktape::Engine.instance.eval! [id, ".", "onCopyClipboard", "(", "\"", entry.buffer.text, "\"", ")"].join
-        end
+        # entry.on_copy_clipboard do
+        #   Duktape::Engine.instance.eval! [id, ".", "onCopyClipboard", "(", "\"", entry.buffer.text, "\"", ")"].join
+        # end
 
-        entry.on_paste_clipboard do
-          Duktape::Engine.instance.eval! [id, ".", "onPasteClipboard", "(", "\"", entry.buffer.text, "\"", ")"].join
-        end
+        # entry.on_paste_clipboard do
+        #   Duktape::Engine.instance.eval! [id, ".", "onPasteClipboard", "(", "\"", entry.buffer.text, "\"", ")"].join
+        # end
 
-        entry.on_activate do
+        entry.activate_signal.connect do
           Duktape::Engine.instance.eval! [id, ".", "onActivate", "(", "\"", entry.buffer.text, "\"", ")"].join
         end
 
@@ -63,15 +63,17 @@ module Haki
           box_padding = box_padding[..box_padding.size - 3]
         end
 
-        entry.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            # TODO: Add an event handler for the components to forward information to JavaScript.
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     # TODO: Add an event handler for the components to forward information to JavaScript.
+        #     true
+        #   end
+        # end
+        # entry.add_controller(event_controller)
 
         containerize(widget, entry, box_expand, box_fill, box_padding)
         add_class_to_css(entry, class_name)

--- a/src/haki/dom/frame.cr
+++ b/src/haki/dom/frame.cr
@@ -27,15 +27,17 @@ module Haki
 
         frame = Gtk::Frame.new(name: id, label: value, halign: horizontal_align, valign: vertical_align)
 
-        frame.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            # TODO: Add an event handler for the components to forward information to JavaScript.
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     # TODO: Add an event handler for the components to forward information to JavaScript.
+        #     true
+        #   end
+        # end
+        # frame.add_controller(event_controller)
 
         containerize(widget, frame, box_expand, box_fill, box_padding)
         add_class_to_css(frame, class_name)

--- a/src/haki/dom/horizontal_separator.cr
+++ b/src/haki/dom/horizontal_separator.cr
@@ -21,7 +21,7 @@ module Haki
         horizontal_align = to_align(@attributes["horizontalAlign"]? || "")
         vertical_align = to_align(@attributes["verticalAlign"]? || "")
 
-        horizontal_separator = Gtk::Separator.new(name: id, orientation: Gtk::Orientation::HORIZONTAL, halign: horizontal_align, valign: vertical_align)
+        horizontal_separator = Gtk::Separator.new(name: id, orientation: Gtk::Orientation::Horizontal, halign: horizontal_align, valign: vertical_align)
 
         box_expand = @attributes["boxExpand"]? || "false"
         box_fill = @attributes["boxFill"]? || "false"
@@ -31,15 +31,17 @@ module Haki
           box_padding = box_padding[..box_padding.size - 3]
         end
 
-        horizontal_separator.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            # TODO: Add an event handler for the components to forward information to JavaScript.
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     # TODO: Add an event handler for the components to forward information to JavaScript.
+        #     true
+        #   end
+        # end
+        # horizontal_separator.add_controller(event_controller)
 
         containerize(widget, horizontal_separator, box_expand, box_fill, box_padding)
         add_class_to_css(horizontal_separator, class_name)

--- a/src/haki/dom/label.cr
+++ b/src/haki/dom/label.cr
@@ -31,15 +31,17 @@ module Haki
 
         Duktape::Engine.instance.eval! ["const", id, "=", {type: "Label", className: class_name, availableCallbacks: ["onEvent"], avaliableFunctions: ["currentValue"]}.to_json].join(" ")
 
-        label.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            # TODO: Add an event handler for the components to forward information to JavaScript.
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     # TODO: Add an event handler for the components to forward information to JavaScript.
+        #     true
+        #   end
+        # end
+        # label.add_controller(event_controller)
 
         containerize(widget, label, box_expand, box_fill, box_padding)
         add_class_to_css(label, class_name)

--- a/src/haki/dom/list_box.cr
+++ b/src/haki/dom/list_box.cr
@@ -27,15 +27,17 @@ module Haki
 
         list_box = Gtk::ListBox.new(name: id, halign: horizontal_align, valign: vertical_align)
 
-        list_box.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            # TODO: Add an event handler for the components to forward information to JavaScript.
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     # TODO: Add an event handler for the components to forward information to JavaScript.
+        #     true
+        #   end
+        # end
+        # list_box.add_controller(event_controller)
 
         containerize(widget, list_box, box_expand, box_fill, box_padding)
         add_class_to_css(list_box, class_name)

--- a/src/haki/dom/scrolled_window.cr
+++ b/src/haki/dom/scrolled_window.cr
@@ -26,15 +26,17 @@ module Haki
 
         scrolled_window = Gtk::ScrolledWindow.new(name: id, halign: horizontal_align, valign: vertical_align)
 
-        scrolled_window.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            # TODO: Add an event handler for the components to forward information to JavaScript.
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     # TODO: Add an event handler for the components to forward information to JavaScript.
+        #     true
+        #   end
+        # end
+        # scrolled_window.add_controller(event_controller)
 
         containerize(widget, scrolled_window, box_expand, box_fill, box_padding)
         add_class_to_css(scrolled_window, class_name)

--- a/src/haki/dom/switch.cr
+++ b/src/haki/dom/switch.cr
@@ -36,21 +36,23 @@ module Haki
 
         Duktape::Engine.instance.eval! ["const", id, "=", {type: "Switch", className: class_name, availableCallbacks: ["onStateSet", "onEvent"]}.to_json].join(" ")
 
-        switch.on_state_set do
-          Duktape::Engine.instance.eval! [id, ".", "onStateSet", "(", switch.active, ")"].join
+        # switch.state_set_signal.connect do
+        #   Duktape::Engine.instance.eval! [id, ".", "onStateSet", "(", switch.active, ")"].join
 
-          true
-        end
+        #   true
+        # end
 
-        switch.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            Duktape::Engine.instance.eval! [id, ".", "onEvent", "(", "\"", event.event_type.to_s, "\"", ")"].join
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     Duktape::Engine.instance.eval! [id, ".", "onEvent", "(", "\"", event.event_type.to_s, "\"", ")"].join
+        #     true
+        #   end
+        # end
+        # switch.add_controller(event_controller)
 
         containerize(widget, switch, box_expand, box_fill, box_padding)
         add_class_to_css(switch, class_name)

--- a/src/haki/dom/tab.cr
+++ b/src/haki/dom/tab.cr
@@ -27,15 +27,17 @@ module Haki
           box_padding = box_padding[..box_padding.size - 3]
         end
 
-        tab.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            # TODO: Add an event handler for the components to forward information to JavaScript.
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     # TODO: Add an event handler for the components to forward information to JavaScript.
+        #     true
+        #   end
+        # end
+        # tab.add_controller(event_controller)
 
         containerize(widget, tab, box_expand, box_fill, box_padding)
         add_class_to_css(tab, class_name)

--- a/src/haki/dom/vertical_separator.cr
+++ b/src/haki/dom/vertical_separator.cr
@@ -21,7 +21,7 @@ module Haki
         horizontal_align = to_align(@attributes["horizontalAlign"]? || "")
         vertical_align = to_align(@attributes["verticalAlign"]? || "")
 
-        vertical_separator = Gtk::Separator.new(name: id, orientation: Gtk::Orientation::VERTICAL, halign: horizontal_align, valign: vertical_align)
+        vertical_separator = Gtk::Separator.new(name: id, orientation: Gtk::Orientation::Vertical, halign: horizontal_align, valign: vertical_align)
 
         box_expand = @attributes["boxExpand"]? || "false"
         box_fill = @attributes["boxFill"]? || "false"
@@ -31,15 +31,17 @@ module Haki
           box_padding = box_padding[..box_padding.size - 3]
         end
 
-        vertical_separator.on_event_after do |_widget, event|
-          case event.event_type
-          when Gdk::EventType::MOTION_NOTIFY
-            false
-          else
-            # TODO: Add an event handler for the components to forward information to JavaScript.
-            true
-          end
-        end
+        # event_controller = Gtk::EventControllerLegacy.new
+        # event_controller.event_signal.connect(after: true) do |event|
+        #   case event.event_type
+        #   when Gdk::EventType::MotionNotify
+        #     false
+        #   else
+        #     # TODO: Add an event handler for the components to forward information to JavaScript.
+        #     true
+        #   end
+        # end
+        # vertical_separator.add_controller(event_controller)
 
         containerize(widget, vertical_separator, box_expand, box_fill, box_padding)
 

--- a/src/haki/dom/window.cr
+++ b/src/haki/dom/window.cr
@@ -36,8 +36,7 @@ module Haki
           default_height: height.to_i
         )
 
-        window.try(&.connect "destroy", &->exit)
-        window.position = Gtk::WindowPosition::CENTER_ALWAYS
+        window.destroy_signal.connect(->exit)
 
         add_class_to_css(window, class_name)
 

--- a/src/haki/duktape/std/gtk.cr
+++ b/src/haki/duktape/std/gtk.cr
@@ -17,10 +17,10 @@ module Haki
                 file = sbx.require_string(-1)
 
                 css_provider = Gtk::CssProvider.new
-                css_provider.load_from_path([folder, file].join("/"))
+                css_provider.load_from_path(Path[folder, file].to_s)
                 display = Gdk::Display.default.not_nil!
-                screen = display.default_screen
-                Gtk::StyleContext.add_provider_for_screen screen, css_provider, Gtk::STYLE_PROVIDER_PRIORITY_APPLICATION
+
+                Gtk::StyleContext.add_provider_for_display(display, css_provider, Gtk::STYLE_PROVIDER_PRIORITY_APPLICATION.to_u32)
               end
 
               sbx.call_success
@@ -36,8 +36,8 @@ module Haki
             css_provider = Gtk::CssProvider.new
             css_provider.load_from_path(file)
             display = Gdk::Display.default.not_nil!
-            screen = display.default_screen
-            Gtk::StyleContext.add_provider_for_screen screen, css_provider, Gtk::STYLE_PROVIDER_PRIORITY_APPLICATION
+
+            Gtk::StyleContext.add_provider_for_display(display, css_provider, Gtk::STYLE_PROVIDER_PRIORITY_APPLICATION.to_u32)
             sbx.call_success
           end
 


### PR DESCRIPTION
Not sure if migrating to gtk4 is planned, but here's an initial attempt! 😅

This PR replaces gtk3 with gtk4.

- ` Gtk::StyleContext#add_provider_for_screen` => `Gtk::StyleContext#add_provider_for_display`
- [`event` signals have been removed](https://docs.gtk.org/gtk4/migrating-3to4.html#gtkwidget-event-signals-are-removed). I replaced them with `Gtk::EventControllerLegacy#event_signal` but it seems to conflict with other signals (e.g. `Gtk::Button#clicked_signal`) so I commented them out.
- [relief properties have been removed](https://docs.gtk.org/gtk4/migrating-3to4.html#stop-using-gtkshadowtype-and-gtkrelief-properties), I used the `has_frame` one instead.
- `Gtk::Entry` no longer has the clipboard signals, [they have instead moved to `Gtk::Text`](https://docs.gtk.org/gtk4/migrating-3to4.html#adapt-to-changes-in-the-api-of-gtkentry-gtksearchentry-and-gtkspinbutton).
- [`Gtk::WindowPosition` has been removed](https://docs.gtk.org/gtk4/migrating-3to4.html#adapt-to-gtkwindow-api-changes).
- There's a type error with `Gtk::Switch#state_set_signal` but made an issue on it https://github.com/hugopl/gi-crystal/issues/66.

The main difference I noticed running the example app is that it doesn't crash after some time due to `Invalid memory access`!